### PR TITLE
Ensure IE11 support

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -4,7 +4,7 @@ module.exports = {
   presets: [
     [
       '@babel/preset-env',
-      { modules: false, exclude: ['transform-typeof-symbol'] },
+      { targets: { ie: '11' }, modules: false, exclude: ['transform-typeof-symbol'] },
     ],
     '@babel/preset-react',
     '@babel/preset-flow',

--- a/examples/advanced-flow/index.js
+++ b/examples/advanced-flow/index.js
@@ -3,6 +3,8 @@ import React, { Component } from 'react';
 import ReactDOM from 'react-dom';
 import { defaults, type Middleware } from 'react-sweet-state';
 
+import '@babel/polyfill';
+
 import { UserListRpc, UserListHook } from './views/user-list';
 import { TodoListRpc, TodoListHook } from './views/todo-list';
 

--- a/examples/advanced-scoped-flow/index.js
+++ b/examples/advanced-scoped-flow/index.js
@@ -3,6 +3,8 @@ import React, { Component } from 'react';
 import ReactDOM from 'react-dom';
 import { defaults } from 'react-sweet-state';
 
+import '@babel/polyfill';
+
 import { ChatRpc } from './views/chat-rpc';
 import { ChatHook } from './views/chat-hook';
 /**

--- a/examples/basic-flow/index.js
+++ b/examples/basic-flow/index.js
@@ -2,6 +2,8 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
 
+import '@babel/polyfill';
+
 import { CounterSubscriber, useCounter } from './components';
 
 const CounterHook = () => {

--- a/examples/performance-test/index.js
+++ b/examples/performance-test/index.js
@@ -2,6 +2,8 @@
 import React, { Component } from 'react';
 import ReactDOM from 'react-dom';
 
+import '@babel/polyfill';
+
 import { TreeRpc } from './views/tree-rpc';
 import { TreeHooks } from './views/tree-hooks';
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1230,6 +1230,30 @@
         "regexpu-core": "^4.1.3"
       }
     },
+    "@babel/polyfill": {
+      "version": "7.4.4",
+      "resolved": "https://registry.npmjs.org/@babel/polyfill/-/polyfill-7.4.4.tgz",
+      "integrity": "sha512-WlthFLfhQQhh+A2Gn5NSFl0Huxz36x86Jn+E9OW7ibK8edKPq+KLy4apM1yDpQ8kJOVi1OVjpP4vSDLdrI04dg==",
+      "dev": true,
+      "requires": {
+        "core-js": "^2.6.5",
+        "regenerator-runtime": "^0.13.2"
+      },
+      "dependencies": {
+        "core-js": {
+          "version": "2.6.5",
+          "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.5.tgz",
+          "integrity": "sha512-klh/kDpwX8hryYL14M9w/xei6vrv6sE8gTHDG7/T/+SEovB/G4ejwcfE/CBzO6Edsu+OETZMZ3wcX/EjUkrl5A==",
+          "dev": true
+        },
+        "regenerator-runtime": {
+          "version": "0.13.2",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.2.tgz",
+          "integrity": "sha512-S/TQAZJO+D3m9xeN1WTI8dLKBBiRgXBlTJvbWjCThHWZj9EvHK70Ff50/tYj2J/fvBY6JtFVwRuazHN2E7M9BA==",
+          "dev": true
+        }
+      }
+    },
     "@babel/preset-env": {
       "version": "7.4.1",
       "resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.4.1.tgz",
@@ -5498,14 +5522,12 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -5520,20 +5542,17 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -5650,8 +5669,7 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "ini": {
           "version": "1.3.5",
@@ -5663,7 +5681,6 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -5678,7 +5695,6 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -5686,14 +5702,12 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "minipass": {
           "version": "2.2.4",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.1",
             "yallist": "^3.0.0"
@@ -5712,7 +5726,6 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -5793,8 +5806,7 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -5806,7 +5818,6 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -5928,7 +5939,6 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -9096,7 +9106,7 @@
         },
         "minimist": {
           "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
           "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
           "dev": true
         },
@@ -9910,7 +9920,7 @@
       "dependencies": {
         "minimist": {
           "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
           "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
           "dev": true
         }
@@ -10488,7 +10498,7 @@
         },
         "minimist": {
           "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
           "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
           "dev": true
         }

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "@babel/plugin-syntax-dynamic-import": "^7.2.0",
     "@babel/plugin-syntax-import-meta": "^7.2.0",
     "@babel/plugin-transform-runtime": "^7.4.0",
+    "@babel/polyfill": "^7.4.4",
     "@babel/preset-env": "^7.4.1",
     "@babel/preset-flow": "^7.0.0",
     "@babel/preset-react": "^7.0.0",

--- a/src/defaults.js
+++ b/src/defaults.js
@@ -3,8 +3,16 @@ const defaultMutator = (prevState, partialState) => {
   return Object.assign({}, prevState, partialState);
 };
 
-export default {
+let middlewares;
+
+const defaults = {
   devtools: false,
-  middlewares: new Set(),
+  get middlewares() {
+    // lazy init to support IE11 + babel polyfill imported after
+    if (!middlewares) middlewares = new Set();
+    return middlewares;
+  },
   mutator: defaultMutator,
 };
+
+export default defaults;


### PR DESCRIPTION
If `babel-polyfill` is imported after `sweet-state`, `middlewares` will be undefined as IE11 does not support `Set` by default. 
The solution is lazy init the `Set` the first time `middlewares` is accessed, so it will work regardless the import order.