### PR TITLE
Add devcontainer configuration

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,32 @@
+FROM node:10
+
+# Configure apt
+ENV DEBIAN_FRONTEND=noninteractive
+RUN apt-get update \
+   && apt-get -y install --no-install-recommends apt-utils 2>&1
+
+# Verify git and process tools are installed
+RUN apt-get install -y git procps
+
+# Remove outdated yarn from /opt and install via package 
+# so it can be easily updated via apt-get upgrade yarn
+RUN rm -rf /opt/yarn-* \
+   && rm -f /usr/local/bin/yarn \
+   && rm -f /usr/local/bin/yarnpkg \
+   && apt-get install -y curl apt-transport-https lsb-release \
+   && curl -sS https://dl.yarnpkg.com/$(lsb_release -is | tr '[:upper:]' '[:lower:]')/pubkey.gpg | apt-key add - 2>/dev/null \
+   && echo "deb https://dl.yarnpkg.com/$(lsb_release -is | tr '[:upper:]' '[:lower:]')/ stable main" | tee /etc/apt/sources.list.d/yarn.list \
+   && apt-get update \
+   && apt-get -y install --no-install-recommends yarn
+
+# Clean up
+RUN apt-get autoremove -y \
+   && apt-get clean -y \
+   && rm -rf /var/lib/apt/lists/*
+ENV DEBIAN_FRONTEND=dialog
+
+ENV SHELL /bin/bash
+
+ENV DEV_SERVER_HOST 0.0.0.0
+
+EXPOSE 8080

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,8 @@
+// See https://aka.ms/vscode-remote/devcontainer.json for format details.
+{
+  "dockerFile": "Dockerfile",
+  "extensions": [],
+  "appPort": [
+    "5337:8080"
+  ]
+}

--- a/README.md
+++ b/README.md
@@ -90,6 +90,11 @@ See sweet-state in action: run `npm run start` and then go and check each folder
 To test your changes you can run the examples (with `npm run start`).
 Also, make sure you run `npm run preversion` before creating you PR so you will double check that linting, types and tests are fine.
 
+### Visual Studio Code Users
+
+If you are using Visual Studio Code, the repo include the necessary configuration to develop inside a container. This way you don't need to install any local dependencies beyond the [Remote Development Extensions](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.vscode-remote-extensionpack) and docker. It also enables developing on windows without the need of tweaking scripts for it. 
+
+
 ## Thanks
 
 This library merges ideas from redux, react-redux, redux-thunk, react-copy-write, unstated, bey, react-apollo just to name a few.

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -5,7 +5,7 @@ const { resolve, basename } = require('path');
 
 // This function generates configuration for files in the
 // ./src/examples/ folder
-const generateExampleEntries = function() {
+const generateExampleEntries = function () {
   const src = './examples';
 
   // Get all subdirectories in the ./src/apps,
@@ -61,6 +61,7 @@ module.exports = {
   devServer: {
     contentBase: resolve(__dirname, 'examples'),
     publicPath: '/',
+    host: process.env.DEV_SERVER_HOST,
     // hot: true,
   },
 };


### PR DESCRIPTION
This PR adds Visual Studio Code configuration for Remote Development.

This way you don't need to install any local dependencies beyond the [Remote Development Extensions](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.vscode-remote-extensionpack) and docker. 

It also enables developing on windows without the need of tweaking scripts for it. 