### PR TITLE
use reduceRight to simplify applyMiddleware

### DIFF
--- a/src/middlewares/index.js
+++ b/src/middlewares/index.js
@@ -3,7 +3,6 @@ import update from './update';
 
 const applyMiddleware = (storeState, middlewares) =>
   [...middlewares, update]
-    .reverse()
-    .reduce((next, mw) => mw(storeState)(next), defaults.mutator);
+    .reduceRight((next, mw) => mw(storeState)(next), defaults.mutator);
 
 export default applyMiddleware;


### PR DESCRIPTION
Not a major change, it seems like it's a small waste to reverse -> reduce, reduceRight should do the same thing.