### PR TITLE
Fix nested actions not bound

### DIFF
--- a/examples/advanced-flow/components/user/actions.js
+++ b/examples/advanced-flow/components/user/actions.js
@@ -8,12 +8,19 @@ const USERS: UserModel[] = [
   { id: '2', name: 'Paul' },
 ];
 
-export const load = (): Action<State> => async ({ setState, getState }) => {
-  if (getState().loading) return;
-
+export const setLoading = (): Action<State> => ({ setState }) => {
   setState({
     loading: true,
   });
+};
+
+export const load = (): Action<State> => async ({
+  setState,
+  getState,
+  actions,
+}) => {
+  if (getState().loading) return;
+  actions.setLoading();
   // simulate async call
   await new Promise(r => setTimeout(r, 1000));
   setState({

--- a/src/store/__tests__/bind-actions.test.js
+++ b/src/store/__tests__/bind-actions.test.js
@@ -26,7 +26,10 @@ describe('bindAction', () => {
       {
         setState: expect.any(Function),
         getState: storeStateMock.getState,
-        actions: actionsMock,
+        actions: expect.objectContaining({
+          increase: expect.any(Function),
+          decrease: expect.any(Function),
+        }),
         dispatch: expect.any(Function),
       },
       containerProps
@@ -60,5 +63,16 @@ describe('bindActions', () => {
       increase: expect.any(Function),
       decrease: expect.any(Function),
     });
+  });
+
+  it('should return actions object with actions bound', () => {
+    const state = { data: null };
+    storeStateMock.getState.mockReturnValue(state);
+    actionsMock.increase.mockReturnValue(({ actions }) => actions.decrease());
+    actionsMock.decrease.mockReturnValue(({ getState }) => getState());
+    const result = bindActions(actionsMock, storeStateMock);
+    const output = result.increase();
+
+    expect(output).toEqual(state);
   });
 });

--- a/src/store/bind-actions.js
+++ b/src/store/bind-actions.js
@@ -10,7 +10,7 @@ export const bindAction = (
   actionFn,
   actionKey,
   getContainerProps = () => {},
-  otherActions = {}
+  boundActions = {}
 ) => {
   // Setting mutator name so we can log action name for better debuggability
   const dispatch = (thunkFn, actionName = `${actionKey}.dispatch`) =>
@@ -20,7 +20,7 @@ export const bindAction = (
           ? namedMutator(storeState, actionName)
           : storeState.mutator,
         getState: storeState.getState,
-        actions: otherActions,
+        actions: boundActions,
         dispatch,
       },
       getContainerProps()
@@ -34,6 +34,6 @@ export const bindActions = (
   getContainerProps = () => ({})
 ) =>
   Object.keys(actions).reduce((acc, k) => {
-    acc[k] = bindAction(storeState, actions[k], k, getContainerProps, actions);
+    acc[k] = bindAction(storeState, actions[k], k, getContainerProps, acc);
     return acc;
   }, {});


### PR DESCRIPTION
`bindAction` was receiving the object with the original actions instead of the bound ones.
Interestingly, Container was already passing the bound actions to onInit and onUpdate but only on the first action. Now it works recursively and everywhere.