### PR TITLE
docs(): fix relative linking

### DIFF
--- a/docs/_sidebar.md
+++ b/docs/_sidebar.md
@@ -1,32 +1,32 @@
 - **Introduction**
 
-  - [Motivation](introduction/motivation.md)
+  - [Motivation](/introduction/motivation.md)
 
 - **Basics**
 
-  - [Store](./basics/store.md)
-  - [Actions](./basics/actions.md)
-  - [Subscribers](./basics/subscriber.md)
-  - [Hooks](./basics/hook.md)
+  - [Store](/basics/store.md)
+  - [Actions](/basics/actions.md)
+  - [Subscribers](/basics/subscriber.md)
+  - [Hooks](/basics/hook.md)
 
 - **Advanced**
 
-  - [Actions patterns](./advanced/actions.md)
-  - [Selectors](./advanced/selector.md)
-  - [Containers](./advanced/container.md)
-  - [Devtools](./advanced/devtools.md)
-  - [State rehydration](./advanced/rehydration.md)
-  - [Middlewares](./advanced/middlewares.md)
+  - [Actions patterns](/advanced/actions.md)
+  - [Selectors](/advanced/selector.md)
+  - [Containers](/advanced/container.md)
+  - [Devtools](/advanced/devtools.md)
+  - [State rehydration](/advanced/rehydration.md)
+  - [Middlewares](/advanced/middlewares.md)
 
 - **APIs**
 
-  - [Actions](./api/actions.md)
-  - [Containers](./api/container.md)
-  - [Hooks](./api/hook.md)
-  - [Store](./api/store.md)
-  - [Subscribers](./api/subscriber.md)
+  - [Actions](/api/actions.md)
+  - [Containers](/api/container.md)
+  - [Hooks](/api/hook.md)
+  - [Store](/api/store.md)
+  - [Subscribers](/api/subscriber.md)
 
 * **Recipes**
 
-  - [Flow types](./recipes/flow.md)
-  - [Composition](./recipes/composition.md)
+  - [Flow types](/recipes/flow.md)
+  - [Composition](/recipes/composition.md)

--- a/docs/index.html
+++ b/docs/index.html
@@ -57,6 +57,7 @@
             'https://github.com/atlassian/react-sweet-state/tree/master/docs/'
           ),
         ],
+        relativePath: true,
       };
     </script>
     <script src="//unpkg.com/docsify/lib/docsify.min.js"></script>


### PR DESCRIPTION
This PR supersedes the 404 fix PR: https://github.com/atlassian/react-sweet-state/pull/20

Changes introduced:
- configuration for relativePath set to true. _Now all links can be set as relative to the context they are rendered in (../../....) or in an aboslute manner (/blah/baha -> base/#/blah/baha)_
- links in the sidebar have been set to absolute given the sidebar is rendered under multiple contexts