### PR TITLE
Ensure state is not updated after unmount

### DIFF
--- a/src/components/__tests__/hook.test.js
+++ b/src/components/__tests__/hook.test.js
@@ -110,6 +110,20 @@ describe('Hook', () => {
     expect(unsubscribeMock).toHaveBeenCalled();
   });
 
+  it('should not set state if updated after unmount', () => {
+    jest.spyOn(console, 'error');
+    const { getMount } = setup();
+    storeStateMock.subscribe.mockReturnValue(jest.fn());
+    const wrapper = getMount();
+    const newState = { count: 1 };
+    storeStateMock.getState.mockReturnValue(newState);
+    const update = storeStateMock.subscribe.mock.calls[0][0];
+    wrapper.unmount();
+    act(() => update(newState));
+
+    expect(console.error).not.toHaveBeenCalled();
+  });
+
   it('should render children with selected return value', () => {
     const selector = jest.fn().mockReturnValue({ foo: 1 });
     const { getMount, children } = setup({ prop: 1 }, selector);

--- a/src/components/hook.js
+++ b/src/components/hook.js
@@ -62,7 +62,10 @@ export function createHook(Store, { selector } = {}) {
     const onUpdateRef = useRef();
     onUpdateRef.current = (updState = prevState, forceUpdate) => {
       const nextState = stateSelector(updState, props);
-      if (!shallowEqual(nextState, currentState) || forceUpdate) {
+      if (
+        subscriptionRef.current &&
+        (!shallowEqual(nextState, currentState) || forceUpdate)
+      ) {
         setState(nextState);
       }
     };


### PR DESCRIPTION
The actual call to update might be deferred and executed after component unmount has been called (like in case of batched updates). So before setting state we ensure the subscription is still live.