### PR TITLE
Fix updates batched in tests

### DIFF
--- a/src/components/__tests__/hook.test.js
+++ b/src/components/__tests__/hook.test.js
@@ -144,6 +144,21 @@ describe('Hook', () => {
     expect(children).toHaveBeenLastCalledWith({ foo: 2 }, actions);
   });
 
+  it('should re-render children with same value if selector output is shallow equal', () => {
+    const selector = () => ({ foo: 1 });
+    const { getMount, children } = setup({ bar: 1 }, selector);
+    const wrapper = getMount();
+    const newState = { count: 1 };
+    storeStateMock.getState.mockReturnValue(newState);
+
+    wrapper.setProps({ bar: 1 });
+
+    // ensure memoisation on selector OUTPUT works
+    const childrenStateInitial = children.mock.calls[0][0];
+    const childrenStateUpdate = children.mock.calls[1][0];
+    expect(childrenStateInitial).toBe(childrenStateUpdate);
+  });
+
   it('should update on state change if selector output is not shallow equal', () => {
     const selector = jest.fn().mockImplementation(() => ({ foo: [1] }));
     const { getMount, children } = setup({}, selector);


### PR DESCRIPTION
Found an unexpected behaviour of React `act()` in tests: it automatically batch updates. Which caused the integration tests that where assessing the subscription call order to pass even if actual update order was wrong!
So I've removed `act()` wrapping on those tests to ensure they still fail when the subscription update order is wrong. 
Also reverting some recent changes on the hook implementation (mainly subscription on mount/update) as subscription update was wrong too.