### PR TITLE
Add custom mutator docs and types fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ sweet-state is heavily inspired by Redux mixed with Context API concepts. It has
 
 Each `Subscriber`, or `Hook`, is responsible to get the instantiated Store (creating a new one with `initialState` if necessary), allowing sharing state across your project extremely easy.
 
-Similar to Redux thunks, actions receive a set of arguments to get and mutate the state. The default `setState` implementation is similar to React `setState`, accepting an object that will be shallow merged with the current state. However, you are free to replace the built-in `setState` logic with a custom implementation, like `immer` for instance.
+Similar to Redux thunks, actions receive a set of arguments to get and mutate the state. The default `setState` implementation is similar to React `setState`, accepting an object that will be shallow merged with the current state. However, you are free to replace the built-in `setState` logic with a custom mutator implementation, like `immer` for instance.
 
 ## Basic usage
 

--- a/docs/advanced/README.md
+++ b/docs/advanced/README.md
@@ -6,3 +6,4 @@
 - [Devtools](./devtools.md)
 - [State rehydration](./rehydration.md)
 - [Middlewares](./middlewares.md)
+- [Custom mutator](./mutator.md)

--- a/docs/advanced/actions.md
+++ b/docs/advanced/actions.md
@@ -23,6 +23,30 @@ const actions = {
 };
 ```
 
+### Generic (and private) actions
+
+Sometimes you might want to have generic actions that are called by other actions, but without exposing them publicly as part the API. That can be easily done using `dispatch`:
+
+```js
+const setLoading = () => ({ setState }) => {
+  setState({ loading: true });
+};
+
+const setData = data => ({ setState }) => {
+  setState({ loading: false, data });
+};
+
+const actions = {
+  load: () => async ({ getState, dispatch }, { api }) => {
+    if (getState().loading === true) return;
+
+    dispatch(setLoading());
+    const todos = await api.get('/todos');
+    dispatch(setData(todos));
+  },
+};
+```
+
 ### Triggering actions on other Stores
 
 Sweet-state does not provide any built-in method to trigger actions on other Stores, however that’s OK as it forces a consistent Flux architecture, where every change apply top down.  

--- a/docs/advanced/mutator.md
+++ b/docs/advanced/mutator.md
@@ -18,7 +18,7 @@ import { produce } from 'immer';
 defaults.mutator = (currentState, producer) => produce(currentState, producer);
 ```
 
-The second argument of the mutator is the parameter you call `setState` with, so it can be anything. For immer it has to be a function, so `setState` will now be called with a producer function instead of a partial state object:
+Generally, the second argument of the mutator is what you call `setState` with, so it can be anything. For immer to work, it has to be a producer function (instead of a partial state object):
 
 ```js
 const actions = {
@@ -31,11 +31,12 @@ const actions = {
 };
 ```
 
-NOTE: if you are using Typescript you will need to overload `SetState` interface otherwise TS will complain. To do that, in your project `types` folder (or where your `typeRoots` config gets additional `d.ts` files) add `react-sweet-state.d.ts` with:
+NOTE: if you are using Typescript you will need to overload `SetState` interface otherwise TS will error. In order to do that, in your project `types` folder (or where your `typeRoots` config gets additional `d.ts` files) add `react-sweet-state.d.ts` with:
 
 ```ts
 declare module 'react-sweet-state' {
   // this allows setState to be called with a function instead of allowing only Partial<TState>
+  // remember also that TState should be writable, as immer expects you to mutate it
   interface SetState<TState> {
     (producer: (draftState: TState) => void): void;
   }

--- a/docs/advanced/mutator.md
+++ b/docs/advanced/mutator.md
@@ -1,0 +1,43 @@
+#### Custom mutator
+
+**sweet-state** allows you to override the default mutator via `defaults.mutator`. The built-in implementation is quite simple:
+
+```js
+const defaultMutator = (currentState, partialState) => {
+  // Merge the partial state and the previous state and return a new object
+  return Object.assign({}, currentState, partialState);
+};
+```
+
+But you can override it with your own implementation, for instance using [immer](https://github.com/mweststrate/immer):
+
+```js
+import { defaults } from 'react-sweet-state';
+import { produce } from 'immer';
+
+defaults.mutator = (currentState, producer) => produce(currentState, producer);
+```
+
+The second argument of the mutator is the parameter you call `setState` with, so it can be anything. For immer it has to be a function, so `setState` will now be called with a producer function instead of a partial state object:
+
+```js
+const actions = {
+  increment: (n) => ({ setState }) => {
+      setState(draft => {
+        draft.count += n;
+      });
+    };
+  },
+};
+```
+
+NOTE: if you are using Typescript you will need to overload `SetState` interface otherwise TS will complain. To do that, in your project `types` folder (or where your `typeRoots` config gets additional `d.ts` files) add `react-sweet-state.d.ts` with:
+
+```ts
+declare module 'react-sweet-state' {
+  // this allows setState to be called with a function instead of allowing only Partial<TState>
+  interface SetState<TState> {
+    (producer: (draftState: TState) => void): void;
+  }
+}
+```

--- a/docs/api/actions.md
+++ b/docs/api/actions.md
@@ -26,7 +26,7 @@ It is the method responsible for triggering actual updates to the store. The def
 setState({ count: 0 });
 ```
 
-Note: You can replace this default implementation with a custom one, for instance with [immer](https://github.com/mweststrate/immer), by overriding `defaults.mutator`.
+Note: You can replace this default implementation with a custom one, ([see mutator docs](../advanced/mutator.md)).
 
 ##### - getState
 

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,7 +1,10 @@
 declare module 'react-sweet-state' {
   import { ComponentType, ReactNode, ReactElement } from 'react';
 
-  type SetState<TState> = (newState: Partial<TState>) => void;
+  interface SetState<TState> {
+    (newState: Partial<TState>): void;
+  }
+
   type GetState<TState> = () => Readonly<TState>;
   type StoreUnsubscribe = () => void;
 
@@ -105,10 +108,7 @@ declare module 'react-sweet-state' {
   const defaults: {
     devtools: boolean;
     middlewares: any;
-    mutator: <TState>(
-      prevState: TState,
-      partialState: Partial<TState>
-    ) => TState;
+    mutator: (currentState: any, setStateArg: any) => any;
   };
 
   type ContainerComponent<TProps> = ComponentType<


### PR DESCRIPTION
Current TS type definition does not allow customisation of `setState` to accomodate a custom mutator. By using an interface we can overload `setState` definition tu allow custom arguments (like a function).
I've also relaxed the types of the default mutator so TS does not complain on the actual implementation of it and `setState` can be called with anything.