### PR TITLE
Update ActionAny to be more generic

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -48,10 +48,10 @@ declare module 'react-sweet-state' {
     ) => ReturnType<T>;
   };
 
-  type ActionAny<TState, TContainerProps = void> = (
+  type ActionAny<TState, TContainerProps = void, TReturnValue = any> = (
     api: StoreActionApi<TState>,
     containerProps: TContainerProps
-  ) => any;
+  ) => TReturnValue;
 
   type BoundActions<
     TState,


### PR DESCRIPTION
Hi, I've just found this in my code and thought that it mind be helpful to other as well.
```ts
  type ActionAny<TState, TContainerProps = void, TReturnValue = any> = (
    api: StoreActionApi<TState>,
    containerProps: TContainerProps
  ) => TReturnValue;
```
Should be BC, because it is a last arg and defaults to original type value.