### PR TITLE
Enforce store type to be object

### DIFF
--- a/src/__tests__/types.flow.js
+++ b/src/__tests__/types.flow.js
@@ -154,6 +154,9 @@ TypeStore = createStore<State, Actions>({ initialState: { bla: 0 }, actions });
 // $ExpectError Store should have actions
 TypeStore = createStore<State, Actions>({ initialState: { count: 0 } });
 
+// $ExpectError Store type should be object
+TypeStore = createStore<string, Actions>({ initialState: '', actions });
+
 // Correct
 TypeStore = createStore<State, Actions>({
   initialState: { count: 0 },

--- a/src/index.js.flow
+++ b/src/index.js.flow
@@ -116,7 +116,7 @@ export type SubscriberComponent<ST, AC, PR> = React$ComponentType<{|
  * createStore
  */
 
-declare export function createStore<ST, AC>({|
+declare export function createStore<ST: {}, AC>({|
   initialState: ST,
   actions: AC,
   name?: string,

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -132,7 +132,7 @@ declare module 'react-sweet-state' {
    */
 
   function createStore<
-    TState,
+    TState extends object,
     TActions extends Record<string, ActionThunk<TState, TActions>>
   >(config: {
     initialState: TState;

--- a/types/test.tsx
+++ b/types/test.tsx
@@ -81,6 +81,9 @@ const TypeStore1 = createStore<State, Actions>({
 // $ExpectError
 const TypeStore2 = createStore<State, Actions>({ initialState: { count: 0 } });
 
+// $ExpectError
+const TypeStore3 = createStore<string, Actions>({ initialState: '', actions });
+
 // Correct
 const TypeStore = createStore<State, Actions>({
   initialState: { count: 0 },


### PR DESCRIPTION
Non object shapes were never really supported and behaved weirdly. This enforces it at type level.
Closes #70 