### PR TITLE
Fix selector returning a function

### DIFF
--- a/src/components/__tests__/hook.test.js
+++ b/src/components/__tests__/hook.test.js
@@ -210,6 +210,19 @@ describe('Hook', () => {
     expect(children).toHaveBeenCalledTimes(1);
     expect(children).toHaveBeenCalledWith(undefined, actions);
   });
+
+  it('should support selectors returning a function on init and update', () => {
+    const selector = state => ({ id }) => state[id];
+    const { getMount, children } = setup({}, selector);
+    getMount();
+
+    const newState = { count: 1 };
+    storeStateMock.getState.mockReturnValue(newState);
+    const update = storeStateMock.subscribe.mock.calls[0][0];
+    act(() => update(storeStateMock.getState(), storeStateMock));
+
+    expect(children).toHaveBeenCalledWith(expect.any(Function), actions);
+  });
 });
 
 describe('createMemoizedSelector', () => {

--- a/src/components/hook.js
+++ b/src/components/hook.js
@@ -53,7 +53,7 @@ export function createHook(Store, { selector } = {}) {
     const currentState = stateSelector(storeState.getState(), propsArg);
     useDebugValue(currentState);
 
-    const triggerUpdate = useState(currentState)[1];
+    const triggerUpdate = useState(() => currentState)[1];
     const propsRef = useRef(propsArg);
     propsRef.current = propsArg;
 
@@ -70,7 +70,7 @@ export function createHook(Store, { selector } = {}) {
         const nextState = stateSelector(updatedState, propsRef.current);
 
         if (nextState !== prevState) {
-          triggerUpdate(nextState);
+          triggerUpdate(() => nextState);
           prevState = nextState;
         }
       };


### PR DESCRIPTION
Returning a function is quite bad as will invalidate memoisation on every state update, yet currently it breaks as `useState` will execute that function on hook mount. By switching to lazy `useState` we can store the selector output into the state even if that is itself a function.