### PR TITLE
Ensure shallowEqual bails out for complex objects

### DIFF
--- a/src/utils/__tests__/shallow-equal.test.js
+++ b/src/utils/__tests__/shallow-equal.test.js
@@ -98,4 +98,46 @@ describe('shallowEqual', () => {
       expect(shallowEqual(valueA, valueB)).toBe(false);
     });
   });
+
+  describe('compare native Promise', () => {
+    it('equal', () => {
+      const valueA = new Promise((r) => r('A'));
+      const valueB = valueA;
+      expect(shallowEqual(valueA, valueB)).toBe(true);
+    });
+
+    it('not equal', () => {
+      const valueA = new Promise((r) => r('A'));
+      const valueB = new Promise((r) => r('A'));
+      expect(shallowEqual(valueA, valueB)).toBe(false);
+    });
+  });
+
+  describe('compare native Set', () => {
+    it('equal', () => {
+      const valueA = new Set();
+      const valueB = valueA;
+      expect(shallowEqual(valueA, valueB)).toBe(true);
+    });
+
+    it('not equal', () => {
+      const valueA = new Set();
+      const valueB = new Set();
+      expect(shallowEqual(valueA, valueB)).toBe(false);
+    });
+  });
+
+  describe('compare native Map', () => {
+    it('equal', () => {
+      const valueA = new Map();
+      const valueB = valueA;
+      expect(shallowEqual(valueA, valueB)).toBe(true);
+    });
+
+    it('not equal', () => {
+      const valueA = new Map();
+      const valueB = new Map();
+      expect(shallowEqual(valueA, valueB)).toBe(false);
+    });
+  });
 });

--- a/src/utils/shallow-equal.js
+++ b/src/utils/shallow-equal.js
@@ -32,8 +32,10 @@ export default function shallowEqual(objA, objB) {
 
     return true;
   } else {
-    // Handle Date, RegExp, String, Number, ...
-    if ('' + objA !== '' + objB) {
+    // Handle Date, RegExp, String, Number, ... and complex objects
+    const strA = '' + objA;
+    const strB = '' + objB;
+    if (strA !== strB || (strA[0] === '[' && strA !== '[object Object]')) {
       return false;
     }
 


### PR DESCRIPTION
Current `shallowEqual` does not flag complex objects as changed, making selectors not trigger re-renders in valid cases. 
Fixes #175 