### PR TITLE
docs: Add Resources tab listing tutorials created by the community

### DIFF
--- a/docs/_sidebar.md
+++ b/docs/_sidebar.md
@@ -27,7 +27,7 @@
 
 - **Resources**
 
-  - [External Tutorials](/resources/tutorial.md)
+  - [External Tutorials](/resources/tutorials.md)
 
 - **APIs**
 

--- a/docs/_sidebar.md
+++ b/docs/_sidebar.md
@@ -25,6 +25,10 @@
 
   - [Actions](/testing/actions.md)
 
+- **Resources**
+
+  - [External Tutorials](/resources/tutorial.md)
+
 - **APIs**
 
   - [Actions](/api/actions.md)

--- a/docs/resources/tutorial.md
+++ b/docs/resources/tutorial.md
@@ -1,0 +1,7 @@
+## External Tutorials
+
+Here you can find some external tutorials created by the community.
+
+- SideGuide has created an interactive tutorial for learning the basics of react-sweet-state.
+Learn how to create a counter app using stores with live editable code samples. Check it out here:
+[https://app.sideguide.dev/react-sweet-state/tutorial](https://app.sideguide.dev/react-sweet-state/tutorial)

--- a/docs/resources/tutorials.md
+++ b/docs/resources/tutorials.md
@@ -1,6 +1,6 @@
 ## External Tutorials
 
-Here you can find some external tutorials created by the community.
+Here you can find some external tutorials created by the community:
 
 - SideGuide has created an interactive tutorial for learning the basics of react-sweet-state.
 Learn how to create a counter app using stores with live editable code samples. Check it out here:

--- a/docs/resources/tutorials.md
+++ b/docs/resources/tutorials.md
@@ -1,6 +1,6 @@
 ## External Tutorials
 
-Here you can find some external tutorials created by the community:
+Here you can find some tutorials created by the community:
 
 - SideGuide has created an interactive tutorial for learning the basics of react-sweet-state.
 Learn how to create a counter app using stores with live editable code samples. Check it out here:


### PR DESCRIPTION
Suggestions to improve docs, user experience, and community engagement:
- Add a resources tab that has links to external tutorials/resources/etc that the community creates to help teach react-sweet-state.

I went ahead and added an "External Tutorials" page featuring an interactive tutorial. This will help potential users to better understand the framework allowing them to try for themselves a real use case without leaving the web. The tutorial itself provides code walkthroughs and an interactive sandbox environment with a counter app example adapted from the docs.

Hope you like this add-on and would love any feedback. 

