### PR TITLE
remove link to missing 'performance tips' page

### DIFF
--- a/docs/_sidebar.md
+++ b/docs/_sidebar.md
@@ -15,7 +15,6 @@
   - [Action patterns](/advanced/actions.md)
   - [Selectors](/advanced/selector.md)
   - [Containers](/advanced/container.md)
-  - [Performance tips](/advanced/performance.md)
   - [Devtools](/advanced/devtools.md)
   - [State rehydration](/advanced/rehydration.md)
   - [Middlewares](/advanced/middlewares.md)


### PR DESCRIPTION
Not sure whether the page that this item links to was removed intentionally and this was just missed in the clean-up.