### PR TITLE
Docs: Add note about store name being unique to avoid clashes

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ const Store = createStore({
         });
       },
   },
-  // optional, mostly used for easy debugging
+  // optional, unique, mostly used for easy debugging
   name: 'counter',
 });
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -30,7 +30,7 @@ const Store = createStore({
         });
       },
   },
-  // optional, mostly used for easy debugging
+  // optional, unique, mostly used for easy debugging
   name: 'counter',
 });
 

--- a/docs/basics/store.md
+++ b/docs/basics/store.md
@@ -24,7 +24,7 @@ const actions = {
 const Store = createStore({ initialState, actions });
 ```
 
-Optionally, you can add a `name` property to the `createStore` configuration object. It will be used as the displayName in Redux Devtools.
+Optionally, you can add a unique `name` property to the `createStore` configuration object. It will be used as the displayName in Redux Devtools.
 
 ```js
 const Store = createStore({ initialState, actions, name: 'counter' });


### PR DESCRIPTION
Update Docs to note that store name, if provided should be unique.

**Context**
We ran into a bug where we had multiple stores with the same name and initial state, which caused a clash and unexpected behaviour. This doesn't fix the underlying problem but it does note that store name should be unique which solves the issue if anyone else runs into this.