### PR TITLE
Enable devtools trace by default

### DIFF
--- a/src/enhancers/__tests__/devtools.test.js
+++ b/src/enhancers/__tests__/devtools.test.js
@@ -55,6 +55,7 @@ describe('withDevtools', () => {
     expect(window.__REDUX_DEVTOOLS_EXTENSION__.connect).toHaveBeenCalledWith({
       name: 'Store store-key@scope',
       serialize: true,
+      trace: true,
     });
     expect(devToolsMock.init).toHaveBeenCalledWith({ count: 0 });
     expect(devToolsMock.subscribe).toHaveBeenCalled();
@@ -64,6 +65,7 @@ describe('withDevtools', () => {
     defaults.devtools = (storeState) => ({
       name: `CustomStore ${storeState.key}`,
       stateSanitizer: jest.fn(),
+      trace: false,
     });
     storeStateMock.getState.mockReturnValue({ count: 0 });
     const store = withDevtools(createStoreMock)();
@@ -73,6 +75,7 @@ describe('withDevtools', () => {
       name: 'CustomStore store-key@scope',
       serialize: true,
       stateSanitizer: expect.any(Function),
+      trace: false,
     });
   });
 

--- a/src/enhancers/devtools.js
+++ b/src/enhancers/devtools.js
@@ -2,7 +2,10 @@ import defaults from '../defaults';
 
 const connectDevTools = (storeState, config) => {
   const devTools = window.__REDUX_DEVTOOLS_EXTENSION__.connect(
-    Object.assign({ name: `Store ${storeState.key}`, serialize: true }, config)
+    Object.assign(
+      { name: `Store ${storeState.key}`, serialize: true, trace: true },
+      config
+    )
   );
   devTools.init(storeState.getState());
   devTools.subscribe((message) => {


### PR DESCRIPTION
Redux devtools has a `trace` functionality that allows to see the action callstack (if source code is compiled properly).
Closes #181 as helps locating the actual `dispatch` line 