### PR TITLE
Fix onContainerUpdate and override compat

### DIFF
--- a/docs/api/container.md
+++ b/docs/api/container.md
@@ -65,9 +65,9 @@ createContainer(Store, [options]);
 
    - `displayName` _(string)_: Used by React to better identify a component. Defaults to `Container(${storeName})`.
 
-   - `onInit` _(Function)_: an action that will be triggered on store initialisation. It overrides store's `handlers.onInit`.
+   - `onInit` _(Function)_: an action that will be triggered on container initialisation. It overrides store's `handlers.onInit` and will be triggered every time the container is mounted.
 
-   - `onUpdate` _(Function)_: an action that will be triggered when props on a container change. It is different from store's `onUpdate` API. It overrides store's `handlers.onContainerUpdate`.
+   - `onUpdate` _(Function)_: an action that will be triggered when props on a container change. It is different from store's `onUpdate` API. It overrides store's `handlers.onContainerUpdate` and it does not receive current/prev props as arguments.
 
    - `onCleanup` _(Function)_: an action that will be triggered after the container has been unmounted and no more consumers of the store instance are present. Useful in case you want to clean up side effects like event listeners or timers. It overrides store's `handlers.onDestroy`.
 

--- a/docs/api/store.md
+++ b/docs/api/store.md
@@ -24,7 +24,7 @@ createStore(config);
      - `onInit` _(Function)_: action triggered on store initialisation
      - `onUpdate` _(Function)_: action triggered on store update
      - `onDestroy` _(Function)_: action triggered on store destroy
-     - `onContainerUpdate` _(Function)_: action triggered when `containedBy` container props change
+     - `onContainerUpdate` _(Function)_: action triggered when `containedBy` container props change, receives next/prev props as arguments
 
 ##### Returns
 

--- a/src/__tests__/integration.test.js
+++ b/src/__tests__/integration.test.js
@@ -2,15 +2,14 @@
 /* eslint-env jest */
 
 import React, { Fragment, memo, useEffect } from 'react';
-import { render } from '@testing-library/react';
-import { act } from 'react-dom/test-utils';
+import { render, act } from '@testing-library/react';
 
 import { createStore, defaultRegistry } from '../store';
 import { createContainer } from '../components/container';
 import { createSubscriber } from '../components/subscriber';
 import { createHook } from '../components/hook';
 
-const actTick = () => act(async () => await Promise.resolve());
+const actTick = () => act(() => Promise.resolve());
 
 const actions = {
   add:

--- a/src/__tests__/integration.test.js
+++ b/src/__tests__/integration.test.js
@@ -308,6 +308,11 @@ describe('Integration', () => {
       'HookWrapper[inner]',
       'SubWrapper',
       'HookWrapper[in-inner]',
+      // this is doubled because legacy container notifies on didUpdate
+      // new implementation will batch and so avoid double render
+      'HookWrapper[inner]',
+      'SubWrapper',
+      'HookWrapper[in-inner]',
     ]);
     calls.splice(0);
 

--- a/src/components/__tests__/container.test.js
+++ b/src/components/__tests__/container.test.js
@@ -136,12 +136,8 @@ describe('Container', () => {
 
     it('should cleanup from global on scope change if no more listeners', async () => {
       jest.spyOn(defaultRegistry, 'deleteStore');
-      StoreMock.actions.increase.mockReturnValue(({ setState }) => {
-        setState({ count: 2 });
-      });
       const Subscriber = createSubscriber(Store, { selector: (s) => s.count });
-      const renderPropChildren = jest.fn().mockReturnValue(null);
-      const children = <Subscriber>{renderPropChildren}</Subscriber>;
+      const children = <Subscriber>{() => null}</Subscriber>;
       const { rerender } = render(<Container scope="s1">{children}</Container>);
       rerender(<Container scope="s2">{children}</Container>);
       await actTick();

--- a/src/components/__tests__/container.test.js
+++ b/src/components/__tests__/container.test.js
@@ -285,5 +285,36 @@ describe('Container', () => {
         defaultCount: 6,
       });
     });
+
+    it('should pass specific props to subscriber actions', () => {
+      const actionInner = jest.fn();
+      StoreMock.actions.increase.mockReturnValue(actionInner);
+      const Subscriber = createSubscriber(Store);
+      const renderPropChildren = jest.fn().mockReturnValue(null);
+      const children = <Subscriber>{renderPropChildren}</Subscriber>;
+      render(
+        <>
+          {children}
+          <Container defaultCount={5}>{children}</Container>
+          <Container defaultCount={6}>{children}</Container>
+        </>
+      );
+      act(() => {
+        // trigger actions in all 3 rendered children
+        renderPropChildren.mock.calls[0][1].increase();
+        renderPropChildren.mock.calls[1][1].increase();
+        renderPropChildren.mock.calls[2][1].increase();
+      });
+
+      expect(actionInner).toHaveBeenCalledWith(expect.any(Object), {
+        defaultCount: undefined,
+      });
+      expect(actionInner).toHaveBeenCalledWith(expect.any(Object), {
+        defaultCount: 5,
+      });
+      expect(actionInner).toHaveBeenCalledWith(expect.any(Object), {
+        defaultCount: 6,
+      });
+    });
   });
 });

--- a/src/components/__tests__/container.test.js
+++ b/src/components/__tests__/container.test.js
@@ -59,11 +59,7 @@ describe('Container', () => {
       const children = <Subscriber>{() => null}</Subscriber>;
       render(<Container scope="s1">{children}</Container>);
 
-      expect(defaultRegistry.getStore).toHaveBeenCalledWith(
-        Store,
-        's1',
-        expect.any(Object)
-      );
+      expect(defaultRegistry.getStore).toHaveBeenCalledWith(Store, 's1');
     });
 
     it('should get closer storeState with scope id if matching', () => {
@@ -84,11 +80,7 @@ describe('Container', () => {
         </Container>
       );
 
-      expect(defaultRegistry.getStore).toHaveBeenCalledWith(
-        Store,
-        's2',
-        expect.any(Object)
-      );
+      expect(defaultRegistry.getStore).toHaveBeenCalledWith(Store, 's2');
     });
 
     it('should get local storeState if local matching', () => {
@@ -104,11 +96,7 @@ describe('Container', () => {
       const children = <Subscriber>{() => null}</Subscriber>;
       render(<Container isGlobal>{children}</Container>);
 
-      expect(defaultRegistry.getStore).toHaveBeenCalledWith(
-        Store,
-        undefined,
-        expect.any(Object)
-      );
+      expect(defaultRegistry.getStore).toHaveBeenCalledWith(Store, undefined);
     });
 
     it('should cleanup from global on unmount if no more listeners', async () => {

--- a/src/components/__tests__/hook.test.js
+++ b/src/components/__tests__/hook.test.js
@@ -1,8 +1,7 @@
 /* eslint-env jest */
 
 import React from 'react';
-import { render } from '@testing-library/react';
-import { act } from 'react-dom/test-utils';
+import { render, act } from '@testing-library/react';
 
 import { StoreMock, storeStateMock } from '../../__tests__/mocks';
 import { createHook, createActionsHook, createStateHook } from '../hook';

--- a/src/components/container.js
+++ b/src/components/container.js
@@ -233,7 +233,8 @@ function useContainedStore(scope, registry, propsRef, check, override) {
       if (!containedStore) {
         const isExisting = registry.hasStore(Store, scope);
         const config = { props: () => propsRef.current.sub, contained: check };
-        const { storeState, actions } = registry.getStore(Store, scope, config);
+        const { storeState } = registry.getStore(Store, scope, config);
+        const actions = bindActions(Store.actions, storeState, config);
         const handlers = bindActions(
           Object.assign({}, Store.handlers, override?.handlers),
           storeState,

--- a/src/components/container.js
+++ b/src/components/container.js
@@ -10,6 +10,7 @@ import PropTypes from 'prop-types';
 
 import { Context } from '../context';
 import { StoreRegistry, bindActions, defaultRegistry } from '../store';
+import memoize from '../utils/memoize';
 import shallowEqual from '../utils/shallow-equal';
 
 const noop = () => () => {};
@@ -198,11 +199,13 @@ export function createContainer(
       // compat fields
       override: {
         Store,
-        handlers: {
-          ...(onInit !== noop && { onInit: () => onInit() }),
-          ...(onCleanup !== noop && { onDestroy: () => onCleanup() }),
-          ...(onUpdate !== noop && { onContainerUpdate: () => onUpdate() }),
-        },
+        handlers: Object.assign(
+          {},
+          onInit !== noop && { onInit: () => onInit() },
+          onCleanup !== noop && { onDestroy: () => onCleanup() },
+          // TODO: on next major pass through next/prev props args
+          onUpdate !== noop && { onContainerUpdate: () => onUpdate() }
+        ),
       },
     });
   }
@@ -217,15 +220,10 @@ function useRegistry(scope, isGlobal, { globalRegistry }) {
   }, [scope, isGlobal, globalRegistry]);
 }
 
-function useContainedStore(scope, registry, props, check, override) {
+function useContainedStore(scope, registry, propsRef, check, override) {
   // Store contained scopes in a map, but throwing it away on scope change
   // eslint-disable-next-line react-hooks/exhaustive-deps
   const containedStores = useMemo(() => new Map(), [scope]);
-
-  // Store props in a ref to avoid re-binding actions when they change and re-rendering all
-  // consumers unnecessarily. The update is handled by an effect on the component instead
-  const propsRef = useRef();
-  propsRef.current = props;
 
   const getContainedStore = useCallback(
     (Store) => {
@@ -234,10 +232,10 @@ function useContainedStore(scope, registry, props, check, override) {
       // so we can provide props to actions (only triggered by children)
       if (!containedStore) {
         const isExisting = registry.hasStore(Store, scope);
-        const config = { props: () => propsRef.current, contained: check };
+        const config = { props: () => propsRef.current.next, contained: check };
         const { storeState, actions } = registry.getStore(Store, scope, config);
         const handlers = bindActions(
-          { ...Store.handlers, ...override?.handlers },
+          Object.assign({}, Store.handlers, override?.handlers),
           storeState,
           config,
           actions
@@ -249,13 +247,14 @@ function useContainedStore(scope, registry, props, check, override) {
           unsubscribe: storeState.subscribe(() => handlers.onUpdate?.()),
         };
         containedStores.set(Store, containedStore);
-        // signal store is contained and ready now, so by the time
-        // consumers subscribe we already have updated the store (if needed)
-        if (!isExisting) handlers.onInit?.();
+        // Signal store is contained and ready now, so by the time
+        // consumers subscribe we already have updated the store (if needed).
+        // Also if override maintain legacy behaviour, triggered on every mount
+        if (!isExisting || override) handlers.onInit?.();
       }
       return containedStore;
     },
-    [containedStores, registry, scope, check, override]
+    [containedStores, scope, registry, propsRef, check, override]
   );
   return [containedStores, getContainedStore];
 }
@@ -282,24 +281,37 @@ function createFunctionContainer({ displayName, override } = {}) {
   function FunctionContainer({ children, scope, isGlobal, ...restProps }) {
     const ctx = useContext(Context);
     const registry = useRegistry(scope, isGlobal, ctx);
+
+    // Store props in a ref to avoid re-binding actions when they change and re-rendering all
+    // consumers unnecessarily. The update is handled by an effect on the component instead
+    const propsRef = useRef({ prev: null, next: restProps });
+    propsRef.current = { prev: propsRef.current.next, next: restProps };
+
     const [containedStores, getContainedStore] = useContainedStore(
       scope,
       registry,
-      restProps,
+      propsRef,
       check,
       override
     );
+
+    // Use a stable object as is passed as value to context Provider
     const api = useApi(check, getContainedStore, ctx);
 
     // This listens for custom props change, and so we trigger container update actions
-    // before the re-render gets to consumers, hence why memo and not effect
-    useMemo(() => {
-      containedStores.forEach(({ handlers }) => {
-        handlers.onContainerUpdate?.();
-      });
-      // Deps are dynamic because we want to notify on any custom prop change
-      // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, Object.values(restProps).concat(containedStores));
+    // before the re-render gets to consumers (hence why memo call on render).
+    // Also we use our own memoize instead of relying on memo itself because number of restProps
+    // might change and react throws if deps array length changes :/
+    useMemo(
+      () =>
+        memoize((stores, nextProps) => {
+          // no need to check if first render as stores will be empty anyway
+          stores.forEach(({ handlers }) => {
+            handlers.onContainerUpdate?.(nextProps, propsRef.current.prev);
+          });
+        }, true),
+      []
+    )(containedStores, restProps);
 
     // This listens for scope change or component unmount, to notify all consumers
     // so all work is done on cleanup

--- a/src/components/container.js
+++ b/src/components/container.js
@@ -232,7 +232,7 @@ function useContainedStore(scope, registry, propsRef, check, override) {
       // so we can provide props to actions (only triggered by children)
       if (!containedStore) {
         const isExisting = registry.hasStore(Store, scope);
-        const config = { props: () => propsRef.current.next, contained: check };
+        const config = { props: () => propsRef.current.sub, contained: check };
         const { storeState, actions } = registry.getStore(Store, scope, config);
         const handlers = bindActions(
           Object.assign({}, Store.handlers, override?.handlers),

--- a/src/components/container.js
+++ b/src/components/container.js
@@ -278,14 +278,20 @@ function createFunctionContainer({ displayName, override } = {}) {
       ? store === override.Store
       : store.containedBy === FunctionContainer;
 
-  function FunctionContainer({ children, scope, isGlobal, ...restProps }) {
+  function FunctionContainer(props) {
+    const { children, ...restProps } = props;
+    const { scope, isGlobal, ...subProps } = restProps;
     const ctx = useContext(Context);
     const registry = useRegistry(scope, isGlobal, ctx);
 
     // Store props in a ref to avoid re-binding actions when they change and re-rendering all
     // consumers unnecessarily. The update is handled by an effect on the component instead
-    const propsRef = useRef({ prev: null, next: restProps });
-    propsRef.current = { prev: propsRef.current.next, next: restProps };
+    const propsRef = useRef({ prev: null, next: restProps, sub: subProps });
+    propsRef.current = {
+      prev: propsRef.current.next,
+      next: restProps,
+      sub: subProps, // TODO remove on next major
+    };
 
     const [containedStores, getContainedStore] = useContainedStore(
       scope,

--- a/src/components/hook.js
+++ b/src/components/hook.js
@@ -9,7 +9,6 @@ const DEFAULT_SELECTOR = (state) => state;
 
 export function createHook(Store, { selector } = {}) {
   return function useSweetState(propsArg) {
-    const [, forceUpdate] = useState({});
     const { retrieveStore } = useContext(Context);
     const { storeState, actions } = retrieveStore(Store);
 
@@ -27,6 +26,7 @@ export function createHook(Store, { selector } = {}) {
       [hasPropsArg, storeState]
     );
 
+    const forceUpdate = useState({})[1];
     const getSnapshot = useCallback(() => {
       // parent scope has changed and notify was explicitly triggered by the container
       // we need to force the hook to re-render to listen new storeState
@@ -34,7 +34,7 @@ export function createHook(Store, { selector } = {}) {
 
       const state = storeState.getState();
       return stateSelector(state, propsArgRef.current);
-    }, [retrieveStore, storeState, stateSelector]);
+    }, [retrieveStore, storeState, stateSelector, forceUpdate]);
 
     const currentState = useSyncExternalStore(
       storeState.subscribe,

--- a/src/store/registry.js
+++ b/src/store/registry.js
@@ -24,8 +24,16 @@ export class StoreRegistry {
     }
 
     const storeState = createStoreState(key, initialState);
-    const boundActions = bindActions(actions, storeState, config);
-    const store = { storeState, actions: boundActions };
+    let boundActions;
+    const store = {
+      storeState,
+      // these are used only when container-less, so we generate them on-demand
+      get actions() {
+        if (!boundActions)
+          boundActions = bindActions(actions, storeState, config);
+        return boundActions;
+      },
+    };
 
     this.stores.set(key, store);
     return store;

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -37,7 +37,10 @@ declare module 'react-sweet-state' {
       onInit?: () => Action<TState, any, any>;
       onUpdate?: () => Action<TState, any, any>;
       onDestroy?: () => Action<TState, any, any>;
-      onContainerUpdate?: () => Action<TState, any, any>;
+      onContainerUpdate?: (
+        nextProps: any,
+        prevProps: any
+      ) => Action<TState, any, any>;
     };
   };
 
@@ -140,25 +143,17 @@ declare module 'react-sweet-state' {
     | GenericContainerComponent<TProps>
     | OverrideContainerComponent<TProps>;
 
+  type BaseContainerProps =
+    | { scope?: string; isGlobal?: never }
+    | { scope?: never; isGlobal?: boolean };
+
   interface GenericContainerComponent<TProps>
-    extends FunctionComponent<
-      PropsWithChildren<{
-        scope?: string;
-        isGlobal?: boolean;
-      }> &
-        TProps
-    > {
+    extends FunctionComponent<PropsWithChildren<BaseContainerProps> & TProps> {
     override?: false;
   }
 
   interface OverrideContainerComponent<TProps>
-    extends FunctionComponent<
-      PropsWithChildren<{
-        scope?: string;
-        isGlobal?: boolean;
-      }> &
-        TProps
-    > {
+    extends FunctionComponent<PropsWithChildren<BaseContainerProps> & TProps> {
     override: true;
   }
 
@@ -212,7 +207,10 @@ declare module 'react-sweet-state' {
             onInit?: () => Action<TState, TContainerProps, any>;
             onUpdate?: () => Action<TState, TContainerProps, any>;
             onDestroy?: () => Action<TState, TContainerProps, any>;
-            onContainerUpdate?: () => Action<TState, TContainerProps, any>;
+            onContainerUpdate?: (
+              nextProps: BaseContainerProps & TContainerProps,
+              prevProps: BaseContainerProps & TContainerProps
+            ) => Action<TState, TContainerProps, any>;
           };
         }
   ): Store<TState, TActions>;

--- a/types/test.tsx
+++ b/types/test.tsx
@@ -435,6 +435,13 @@ Test = (
   <TypeContainer foo="1">bla</TypeContainer>
 );
 
+Test = (
+  // @ts-expect-error cannot use both isGlobal and scope
+  <TypeContainer isGlobal scope="a">
+    bla
+  </TypeContainer>
+);
+
 // Correct
 Test = <TypeContainer>bla</TypeContainer>;
 Test = <TypeContainer scope="a">bla</TypeContainer>;
@@ -475,6 +482,13 @@ Test = (
   <TypeSharedContainer foo="1">bla</TypeSharedContainer>
 );
 
+Test = (
+  // @ts-expect-error cannot use both isGlobal and scope
+  <TypeContainer isGlobal scope="a">
+    bla
+  </TypeContainer>
+);
+
 // Correct
 Test = <TypeSharedContainer>bla</TypeSharedContainer>;
 Test = <TypeSharedContainer scope="a">bla</TypeSharedContainer>;
@@ -497,6 +511,10 @@ createStore({
       },
     onUpdate: () => () => undefined,
     onDestroy: () => () => undefined,
-    onContainerUpdate: () => () => undefined,
+    onContainerUpdate: (nextProps, prevProps) => () => {
+      const isSameScope = nextProps.scope === prevProps.scope;
+      const isSameGlobal = nextProps.isGlobal === prevProps.isGlobal;
+      const isSameValue = nextProps.initValue === prevProps.initValue;
+    },
   },
 });


### PR DESCRIPTION
Fix a couple of regressions with the container implementation:

- new implementation did not fire `onInit` on every mount with override mode (current expected behaviour)
- call new `onContainerUpdate` with next/prev props as arguments
- fix `onContainerUpdate` being called continuously and generating re-render loops
- fix a bug on hook store subscription not picking up new subscription on scope change if oldState == newState