### PR TITLE
Support childless global containers pattern

### DIFF
--- a/src/components/__tests__/container.test.js
+++ b/src/components/__tests__/container.test.js
@@ -229,6 +229,26 @@ describe('Container', () => {
       expect(onInit).toHaveBeenCalledTimes(1);
     });
 
+    it('should call Container onInit when global and override even with no subscriber children', () => {
+      const Subscriber = createSubscriber(Store);
+      mockOnContainerInitInner.mockImplementationOnce(({ setState }) =>
+        setState({ count: 1 })
+      );
+      const renderPropChildren = jest.fn().mockReturnValue(null);
+      render(
+        <>
+          <Container isGlobal />
+          <Subscriber>{renderPropChildren}</Subscriber>
+        </>
+      );
+
+      expect(mockOnContainerInitInner).toHaveBeenCalledTimes(1);
+      expect(renderPropChildren).toHaveBeenCalledWith(
+        { count: 1 },
+        expect.any(Object)
+      );
+    });
+
     it('should call Container onUpdate on re-render if props changed', () => {
       const Subscriber = createSubscriber(Store);
       const renderPropChildren = jest.fn().mockReturnValue(null);


### PR DESCRIPTION
The new Container implementation is lazy by default (does not create a store until a subscriber asks for it) but current implementation allows container to be mounted as sibling to initialise global stores.

So we add a test to ensure we still support this use case. That also found another scenario where `isGlobal` stores might get cleaned up accidentally