### PR TITLE
Remove legacy container implementation

### DIFF
--- a/src/__tests__/integration.test.js
+++ b/src/__tests__/integration.test.js
@@ -180,9 +180,7 @@ describe('Integration', () => {
 
     const state3 = { loading: false, todos: ['todoB'] };
     const call3 = 3;
-    // its 3+1 because on scope change we do NOT use context and force notify
-    // causing ones that have naturally re-rendered already to re-render once more.
-    expect(children1.mock.calls[call3 + 1]).toEqual([state3, expectActions]);
+    expect(children1.mock.calls[call3]).toEqual([state3, expectActions]);
     expect(children2.mock.calls[call3]).toEqual([state3, expectActions]);
   });
 
@@ -305,11 +303,6 @@ describe('Integration', () => {
 
     expect(calls).toEqual([
       'HookWrapper[outter]',
-      'HookWrapper[inner]',
-      'SubWrapper',
-      'HookWrapper[in-inner]',
-      // this is doubled because legacy container notifies on didUpdate
-      // new implementation will batch and so avoid double render
       'HookWrapper[inner]',
       'SubWrapper',
       'HookWrapper[in-inner]',

--- a/src/components/__tests__/container.test.js
+++ b/src/components/__tests__/container.test.js
@@ -25,6 +25,10 @@ const Container = createContainer(Store, {
   onUpdate: mockOnContainerUpdate,
   onCleanup: () => mockOnContainerCleanupInner,
 });
+const configArg = {
+  contained: expect.any(Function),
+  props: expect.any(Function),
+};
 
 describe('Container', () => {
   beforeEach(() => {
@@ -59,7 +63,11 @@ describe('Container', () => {
       const children = <Subscriber>{() => null}</Subscriber>;
       render(<Container scope="s1">{children}</Container>);
 
-      expect(defaultRegistry.getStore).toHaveBeenCalledWith(Store, 's1');
+      expect(defaultRegistry.getStore).toHaveBeenCalledWith(
+        Store,
+        's1',
+        configArg
+      );
     });
 
     it('should get closer storeState with scope id if matching', () => {
@@ -80,7 +88,11 @@ describe('Container', () => {
         </Container>
       );
 
-      expect(defaultRegistry.getStore).toHaveBeenCalledWith(Store, 's2');
+      expect(defaultRegistry.getStore).toHaveBeenCalledWith(
+        Store,
+        's2',
+        configArg
+      );
     });
 
     it('should get local storeState if local matching', () => {
@@ -96,7 +108,11 @@ describe('Container', () => {
       const children = <Subscriber>{() => null}</Subscriber>;
       render(<Container isGlobal>{children}</Container>);
 
-      expect(defaultRegistry.getStore).toHaveBeenCalledWith(Store, undefined);
+      expect(defaultRegistry.getStore).toHaveBeenCalledWith(
+        Store,
+        undefined,
+        configArg
+      );
     });
 
     it('should cleanup from global on unmount if no more listeners', async () => {

--- a/src/components/container.js
+++ b/src/components/container.js
@@ -1,5 +1,4 @@
 import React, {
-  Component,
   useCallback,
   useContext,
   useMemo,
@@ -9,174 +8,10 @@ import React, {
 import PropTypes from 'prop-types';
 
 import { Context } from '../context';
-import { StoreRegistry, bindActions, defaultRegistry } from '../store';
+import { StoreRegistry, bindActions } from '../store';
 import shallowEqual from '../utils/shallow-equal';
 
 const noop = () => () => {};
-
-export default class Container extends Component {
-  static propTypes = {
-    children: PropTypes.node,
-    scope: PropTypes.string,
-    isGlobal: PropTypes.bool,
-  };
-
-  static storeType = null;
-  static hooks = null;
-  static contextType = Context;
-
-  static getDerivedStateFromProps(nextProps, prevState) {
-    const { scope } = nextProps;
-    const hasScopeChanged = scope !== prevState.scope;
-
-    let nextState = null;
-    if (hasScopeChanged) {
-      const actions = prevState.bindContainerActions(scope);
-      nextState = {
-        scope,
-        scopedActions: actions,
-      };
-    }
-    // We trigger the action here so subscribers get new values ASAP
-    prevState.triggerContainerAction(nextProps);
-    return nextState;
-  }
-
-  constructor(props, context) {
-    super(props, context);
-
-    const {
-      // These fallbacks are needed only to make enzyme shallow work
-      // as it does not fully support provider-less Context enzyme#1553
-      globalRegistry = defaultRegistry,
-      retrieveStore = defaultRegistry.getStore,
-    } = this.context;
-
-    this.state = {
-      api: {
-        globalRegistry,
-        retrieveStore: (Store, scope) =>
-          this.constructor.storeType === Store
-            ? this.getScopedStore(scope)
-            : retrieveStore(Store),
-      },
-      // stored to make them available in getDerivedStateFromProps
-      // as js context there is null https://github.com/facebook/react/issues/12612
-      bindContainerActions: this.bindContainerActions,
-      triggerContainerAction: this.triggerContainerAction,
-      scope: props.scope,
-    };
-    this.state.scopedActions = this.bindContainerActions(props.scope);
-  }
-
-  registry = new StoreRegistry('__local__');
-  scopedHooks = {};
-
-  componentDidUpdate(prevProps) {
-    if (this.props.scope !== prevProps.scope) {
-      const { storeState } = this.getScopedStore(prevProps.scope);
-      // Trigger a forced update on all subscribers as render might have been blocked
-      // When called, subscribers that have already re-rendered with the new scope
-      // are no longer subscribed to the old one, so we "force update" the remaining.
-      // This is sub-optimal as if there are other containers with the same
-      // old scope id we will re-render those too, but still better than using context
-      storeState.notify();
-      // Schedule check if instance has still subscribers, if not delete
-      Promise.resolve().then(() => {
-        this.deleteScopedStore(storeState, prevProps.scope);
-      });
-    }
-  }
-
-  componentWillUnmount() {
-    let scopedStore = this.props.scope ? this.getScopedStore() : null;
-    // schedule on next tick as this is called by React before useEffect cleanup
-    // so if we run immediately listeners will still be there and run
-    Promise.resolve().then(() => {
-      this.scopedHooks.onCleanup();
-      // Check if scope has still subscribers, if not delete
-      if (scopedStore) this.deleteScopedStore(scopedStore.storeState);
-    });
-  }
-
-  bindContainerActions = (scope) => {
-    const { storeType, hooks } = this.constructor;
-    const { api } = this.state;
-    // we explicitly pass scope as it might be changed
-    const { storeState } = api.retrieveStore(storeType, scope);
-
-    const config = {
-      props: () => this.actionProps,
-      contained: (s) => storeType === s,
-    };
-
-    const actions = bindActions(storeType.actions, storeState, config);
-    this.scopedHooks = bindActions(hooks, storeState, config, actions);
-
-    // make sure we also reset actionProps
-    this.actionProps = null;
-    return actions;
-  };
-
-  triggerContainerAction = (nextProps) => {
-    const nextActionProps = this.filterActionProps(nextProps);
-    const prevActionProps = this.actionProps;
-    if (shallowEqual(prevActionProps, nextActionProps)) return;
-
-    // store restProps on instance so we can diff and use fresh props
-    // in actions even before react sets them in this.props
-    this.actionProps = nextActionProps;
-
-    if (this.scopedHooks.onInit) {
-      this.scopedHooks.onInit();
-      this.scopedHooks.onInit = null;
-    } else {
-      this.scopedHooks.onUpdate();
-    }
-  };
-
-  filterActionProps = (props) => {
-    // eslint-disable-next-line no-unused-vars
-    const { children, scope, isGlobal, ...restProps } = props;
-    return restProps;
-  };
-
-  getRegistry() {
-    const isLocal = !this.props.scope && !this.props.isGlobal;
-    return isLocal ? this.registry : this.state.api.globalRegistry;
-  }
-
-  getScopedStore(scopeId = this.props.scope) {
-    const { storeType } = this.constructor;
-    const { storeState } = this.getRegistry().getStore(storeType, scopeId);
-    // instead of returning global bound actions
-    // we return the ones with the countainer props binding
-    return {
-      storeState,
-      actions: this.state.scopedActions,
-    };
-  }
-
-  deleteScopedStore(prevStoreState, scopeId = this.props.scope) {
-    const { storeState } = this.getScopedStore(scopeId);
-    if (
-      scopeId != null &&
-      !prevStoreState.listeners().size &&
-      // ensure registry has not already created a new store w/ same scope
-      prevStoreState === storeState
-    ) {
-      const { storeType } = this.constructor;
-      this.getRegistry().deleteStore(storeType, scopeId);
-    }
-  }
-
-  render() {
-    const { children } = this.props;
-    return (
-      <Context.Provider value={this.state.api}>{children}</Context.Provider>
-    );
-  }
-}
 
 export function createContainer(
   StoreOrOptions = {},
@@ -186,13 +21,6 @@ export function createContainer(
     const Store = StoreOrOptions;
     const dn = displayName || `Container(${Store.key.split('__')[0]})`;
 
-    return class extends Container {
-      static storeType = Store;
-      static displayName = dn;
-      static hooks = { onInit, onUpdate, onCleanup };
-    };
-
-    // eslint-disable-next-line no-unreachable
     return createFunctionContainer({
       displayName: dn,
       // compat fields


### PR DESCRIPTION
Legacy implementation contains a potential memory leak and we don't need it anymore.