### PR TITLE
Add unstable_concurrent behaviour

### DIFF
--- a/examples/batch-order/controllers/alpha.tsx
+++ b/examples/batch-order/controllers/alpha.tsx
@@ -1,0 +1,37 @@
+import {
+  StoreActionApi,
+  createStore,
+  createContainer,
+  createStateHook,
+  createActionsHook,
+} from 'react-sweet-state';
+
+type State = {
+  value: number;
+};
+
+type StoreAPI = StoreActionApi<State>;
+
+const setValue =
+  (value: number) =>
+  ({ setState }: StoreAPI) => {
+    setState({ value });
+  };
+
+const actions = { setValue };
+
+const Store = createStore<State, typeof actions>({
+  initialState: { value: 0 },
+  actions,
+  name: 'alpha',
+});
+
+export const AlphaContainer = createContainer<State, typeof actions>(Store, {
+  displayName: 'AlphaContainer',
+});
+
+export const useAlphaValue = createStateHook(Store, {
+  selector: (state: State) => state.value,
+});
+
+export const useAlphaActions = createActionsHook(Store);

--- a/examples/batch-order/controllers/beta.tsx
+++ b/examples/batch-order/controllers/beta.tsx
@@ -1,0 +1,46 @@
+import {
+  StoreActionApi,
+  createStore,
+  createContainer,
+  createStateHook,
+  defaults,
+} from 'react-sweet-state';
+
+type Props = {
+  input: number;
+};
+
+type State = {
+  ouput: number | undefined;
+};
+
+type StoreAPI = StoreActionApi<State>;
+
+const init =
+  () =>
+  ({ setState }: StoreAPI, { input }: Props) => {
+    console.log('===== updating beta', input);
+    setState({ ouput: input });
+    if (input > 0) throw new Error('');
+  };
+
+const actions = {};
+
+const Store = createStore<State, typeof actions>({
+  initialState: { ouput: undefined },
+  actions,
+  name: 'beta',
+});
+
+export const BetaContainer = createContainer<State, typeof actions, Props>(
+  Store,
+  {
+    displayName: 'BetaContainer',
+    onInit: init,
+    onUpdate: init,
+  }
+);
+
+export const useBetaValue = createStateHook(Store, {
+  selector: (state) => state.ouput,
+});

--- a/examples/batch-order/controllers/gamma.tsx
+++ b/examples/batch-order/controllers/gamma.tsx
@@ -1,0 +1,44 @@
+import {
+  StoreActionApi,
+  createStore,
+  createContainer,
+  createStateHook,
+} from 'react-sweet-state';
+
+type Props = {
+  input: number | undefined;
+};
+
+type State = {
+  ouput: number | undefined;
+};
+
+type StoreAPI = StoreActionApi<State>;
+
+const init =
+  () =>
+  ({ setState }: StoreAPI, { input }: Props) => {
+    console.log('===== updating gamma');
+    setState({ ouput: input });
+  };
+
+const actions = {};
+
+const Store = createStore<State, typeof actions>({
+  initialState: { ouput: undefined },
+  actions,
+  name: 'gamma',
+});
+
+export const GammaContainer = createContainer<State, typeof actions, Props>(
+  Store,
+  {
+    displayName: 'GammaContainer',
+    onInit: init,
+    onUpdate: init,
+  }
+);
+
+export const useGammaValue = createStateHook(Store, {
+  selector: (state) => state.ouput,
+});

--- a/examples/batch-order/index.html
+++ b/examples/batch-order/index.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Basic example with TypeScript</title>
+    <style>
+      body {
+        font-family: sans-serif;
+      }
+      main {
+        display: flex;
+        line-height: 1.5;
+      }
+      hr {
+        margin: 1em;
+      }
+    </style>
+  </head>
+
+  <body>
+    <div id="root"></div>
+    <script src="./bundle.js" type="text/javascript"></script>
+  </body>
+</html>

--- a/examples/batch-order/index.tsx
+++ b/examples/batch-order/index.tsx
@@ -1,0 +1,54 @@
+import React, { ReactNode } from 'react';
+import ReactDOM from 'react-dom/client';
+
+import {
+  AlphaContainer,
+  useAlphaActions,
+  useAlphaValue,
+} from './controllers/alpha';
+import { BetaContainer, useBetaValue } from './controllers/beta';
+import { GammaContainer, useGammaValue } from './controllers/gamma';
+
+// uncomment and reload to "fix" behaviour
+import { defaults } from 'react-sweet-state';
+defaults.batchUpdates = false;
+
+const WiredBetaContainer = (props: { children?: ReactNode }) => {
+  console.log('Beta', 'useAlphaValue()', useAlphaValue());
+  return <BetaContainer input={useAlphaValue()} {...props} />;
+};
+
+const WiredGammaContainer = (props: { children?: ReactNode }) => {
+  console.log('Gamma');
+  return <GammaContainer input={useBetaValue()} {...props} />;
+};
+
+const Delta = () => {
+  const alphaValue = useAlphaValue();
+  const gammaValue = useGammaValue();
+
+  console.log('Delta', alphaValue, gammaValue);
+
+  const { setValue } = useAlphaActions();
+
+  return (
+    <button type="button" onClick={() => setValue((alphaValue ?? 0) + 1)}>
+      Update
+    </button>
+  );
+};
+
+function App() {
+  return (
+    <AlphaContainer>
+      <WiredBetaContainer>
+        <WiredGammaContainer>
+          <Delta />
+        </WiredGammaContainer>
+      </WiredBetaContainer>
+    </AlphaContainer>
+  );
+}
+
+const root = ReactDOM.createRoot(document.getElementById('root')!);
+root.render(<App />);

--- a/examples/concurrent/components.tsx
+++ b/examples/concurrent/components.tsx
@@ -1,0 +1,28 @@
+import { createStore, createHook, defaults, Action } from 'react-sweet-state';
+
+defaults.unstable_concurrent = false;
+
+type State = {
+  count: number;
+};
+
+const initialState: State = {
+  count: 0,
+};
+
+const actions = {
+  increment:
+    (): Action<State> =>
+    ({ setState, getState }) => {
+      setState({
+        count: getState().count + 1,
+      });
+    },
+};
+
+const Store = createStore({
+  initialState,
+  actions,
+});
+
+export const useCounter = createHook(Store);

--- a/examples/concurrent/index.html
+++ b/examples/concurrent/index.html
@@ -1,0 +1,44 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Concurrent example</title>
+    <style>
+      body {
+        font-family: sans-serif;
+      }
+      hr {
+        margin: 1em;
+      }
+      #fps {
+        background: #333;
+        color: #fff;
+        padding: 1em;
+      }
+      #fps::before {
+        content: 'FPS: ';
+      }
+    </style>
+  </head>
+
+  <body>
+    <div id="fps">0</div>
+    <div id="root"></div>
+    <script src="./bundle.js" type="text/javascript"></script>
+    <script>
+      let counter = 0;
+      let start = Date.now();
+      const el = document.querySelector('#fps');
+      function fps() {
+        const now = Date.now();
+        counter++;
+        if (now - start > 1000) {
+          el.innerHTML = counter;
+          counter = 0;
+          start = now;
+        }
+        window.requestAnimationFrame(fps);
+      }
+      fps();
+    </script>
+  </body>
+</html>

--- a/examples/concurrent/index.tsx
+++ b/examples/concurrent/index.tsx
@@ -1,0 +1,43 @@
+import React, { StrictMode } from 'react';
+import ReactDOM from 'react-dom/client';
+
+import { useCounter } from './components';
+
+export const Expensive = () => {
+  // Hog main thread for 500 milliseconds
+  const start = Date.now();
+  while (Date.now() - start < 100) {
+    // do nothing
+  }
+  console.log('Render Expensive');
+
+  return <div style={{ border: '1px solid black' }}>Expensive</div>;
+};
+
+/**
+ * Main App
+ */
+const App = () => {
+  const [{ count }, { increment }] = useCounter();
+
+  return (
+    <div>
+      <h1>Expensive counter example</h1>
+      <main>
+        <p>{count}</p>
+        <button onClick={increment}>+1</button>
+        <hr />
+        {[1, 2, 3, 4, 5, 6, 7, 8, 9, 10].map((value) => (
+          <Expensive key={value} />
+        ))}
+      </main>
+    </div>
+  );
+};
+
+const root = ReactDOM.createRoot(document.getElementById('root')!);
+root.render(
+  <StrictMode>
+    <App />
+  </StrictMode>
+);

--- a/src/defaults.js
+++ b/src/defaults.js
@@ -10,6 +10,7 @@ const defaults = {
   devtools: false,
   middlewares: new Set(),
   mutator: defaultMutator,
+  unstable_concurrent: undefined,
 };
 
 export default defaults;

--- a/src/store/create-state.js
+++ b/src/store/create-state.js
@@ -1,9 +1,11 @@
+import { startTransition } from 'react';
+
 import applyMiddleware from '../middlewares';
 import withDevtools from '../enhancers/devtools';
 import defaults from '../defaults';
 import schedule from '../utils/schedule';
 
-function createStoreState(key, initialState) {
+function createStoreState(key, initialState, unstable_concurrent) {
   let listeners = new Set();
   let currentState = initialState;
   const storeState = {
@@ -13,9 +15,13 @@ function createStoreState(key, initialState) {
     },
     setState(nextState) {
       currentState = nextState;
-      // Instead of notifying all handlers immediately, we wait next tick
-      // so multiple actions affecting the same store gets combined
-      schedule(storeState.notify);
+      if (defaults.unstable_concurrent && unstable_concurrent !== false) {
+        startTransition(storeState.notify);
+      } else {
+        // Instead of notifying all handlers immediately, we wait next tick
+        // so multiple actions affecting the same store gets combined
+        schedule(storeState.notify);
+      }
     },
     resetState() {
       storeState.setState(initialState);

--- a/src/store/create.js
+++ b/src/store/create.js
@@ -13,6 +13,7 @@ export function createStore({
   name = '',
   initialState,
   actions,
+  unstable_concurrent,
   containedBy,
   handlers = {},
 }) {
@@ -26,5 +27,6 @@ export function createStore({
     actions,
     containedBy,
     handlers,
+    unstable_concurrent,
   };
 }

--- a/src/store/registry.js
+++ b/src/store/registry.js
@@ -23,7 +23,11 @@ export class StoreRegistry {
       else throw err;
     }
 
-    const storeState = createStoreState(key, initialState);
+    const storeState = createStoreState(
+      key,
+      initialState,
+      Store.unstable_concurrent
+    );
     let boundActions;
     const store = {
       storeState,

--- a/src/utils/batched-updates.js
+++ b/src/utils/batched-updates.js
@@ -14,6 +14,7 @@ export function batch(fn) {
   // if we are in node/tests or nested schedule
   if (
     !defaults.batchUpdates ||
+    defaults.unstable_concurrent === true ||
     !supports.scheduling() ||
     isInsideBatchedSchedule
   ) {

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -135,6 +135,7 @@ declare module 'react-sweet-state' {
     devtools: boolean | ((storeState: StoreState<any>) => Record<string, any>);
     middlewares: Set<Middleware>;
     mutator: (currentState: any, setStateArg: any) => any;
+    unstable_concurrent: boolean;
   };
 
   function batch(callback: () => any): void;
@@ -195,6 +196,7 @@ declare module 'react-sweet-state' {
           initialState: TState;
           actions: TActions;
           name?: string;
+          unstable_concurrent?: boolean;
           containedBy?: never;
           handlers?: never;
         }
@@ -202,6 +204,7 @@ declare module 'react-sweet-state' {
           initialState: TState;
           actions: TActions;
           name?: string;
+          unstable_concurrent?: boolean;
           containedBy: GenericContainerComponent<TContainerProps>;
           handlers?: {
             onInit?: () => Action<TState, TContainerProps, any>;


### PR DESCRIPTION
After the long conversation in #219 , this PR tries to ratify the behaviour.

First of all, let's be clear on the end state: there is no batching and scheduling done by RSS. We use `startTransition` and only provide concurrent opt-out via global settings or per-store. 
Given we need time to investigate the impact (and Atlassian is not ready for that anyway), we will use `defaults.unstable_concurrent` to test the performance of dropping our custom scheduler.

So, by default this PR only fixes the warning that `defaults.batchUpdates = false` has on React 17+.

For Jira, we can play around with  `defaults.unstable_concurrent = true | false | undefined`, where:
- `undefined` is the current container implementation + uSES + batching (if enabled)
- `false` is the new container implementation + uSES + batching (if enabled)
- `true` is startTransition + no uSES + no batching